### PR TITLE
Show CV feedback form by default

### DIFF
--- a/cv_feedback.php
+++ b/cv_feedback.php
@@ -209,7 +209,7 @@
     <section class="kcvf-formwrap" id="enviar-cv">
       <h3>Envía tu CV para feedback</h3>
       <p>Sube tu documento y recibe recomendaciones en pocos minutos.</p>
-      <div class="kcvf-shortcode">
+      <div class="kcvf-shortcode" style="display:block">
         <strong>[kovacic_cv_submit]</strong>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Ensure the CV feedback submission form is visible by default.

## Testing
- `php -l cv_feedback.php`
- `php -l cv_fb_plugin`


------
https://chatgpt.com/codex/tasks/task_e_68b1b2ec9508832aa3fe2620b1e3b1b5